### PR TITLE
Stop plotWithManyBars from crashing for NA values

### DIFF
--- a/orfwxfunctions.R
+++ b/orfwxfunctions.R
@@ -46,6 +46,11 @@ plotWithManyBars <- function(sortedData,
                              yAxisLabelPlotWmb,
                              plottingPrecip = FALSE,
                              showAllLabels = FALSE) {
+  # Discard missing values (so they don't become maxSortedData)
+  sortedData <- na.omit(sortedData)
+  sortedDataFrame <- na.omit(sortedDataFrame)
+  # TODO: Handle the edge case where sortedDataFrame has missing year values.
+  
   # Convenience variables:
   minSortedData <- sortedData[1]
   maxSortedData <- sortedData[length(sortedData)]


### PR DESCRIPTION
Fix a crash triggered by calling `plotWithManyBars` from `plotMinTempOverHistory(11, 21)` due to `NA` value for the low temperature on November 21, 1880.