### PR TITLE
20170202 feb plots non leap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@ I am successful in that undertaking.
 Consult [the Github repository](github.com/verumsolum/orf_weather) if you
 require details about earlier changes.
 
+### Changes in version 0.0.0.9046 (2017-02-02)
+* *showLeapDay* parameter: Added to `computeCumulativePrecipRecords` and
+`plot?TDPrecipitation`functions. Data for Feb 29th will be hidden from those
+functions unless `showLeapDay` is set to `TRUE`. (Defaults to `TRUE` during leap
+years and `FALSE` at all other times.)
+
 ### Changes in version 0.0.0.9045 (2017-02-02)
 * **removeBackups**: Function added to remove backup files from `/.orfwx/` 
 directory (either after seven days, or all but the most recent backup files).

--- a/orfwx/DESCRIPTION
+++ b/orfwx/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orfwx
 Title: ORF Weather Utilities
-Version: 0.0.0.9045
+Version: 0.0.0.9046
 Authors@R: person("Kristin", "Rollins", email = "dev@kristin.verumsolum.com", 
                   role = c("aut", "cre"))
 Description: Various utilities are provided for creating @ORF_Weather tweets.

--- a/orfwx/R/computecumulativepreciprecords.R
+++ b/orfwx/R/computecumulativepreciprecords.R
@@ -210,5 +210,8 @@ computeCumulativePrecipRecords <-
       }
     }
     
+    # TODO: Provide code to print label on Feb 28th if it is missing because
+    #       it is identical to Feb 29th. (Not a problem with current data.)
+    
     return(recordsFrame)
 }

--- a/orfwx/R/computecumulativepreciprecords.R
+++ b/orfwx/R/computecumulativepreciprecords.R
@@ -14,6 +14,8 @@
 #'   year's data for comparison (defaults to \code{FALSE}).
 #' @param includeNormals (optional) Whether or not to show the 1981-2010 
 #'   normals for comparison (defaults to \code{FALSE}).
+#' @param showLeapDay (optional) Whether or not to show data for February 29th
+#'   (defaults to \code{FALSE}, unless the current year is a leap year).
 #' @return Returns a data frame.
 #' @examples
 #' \dontrun{computeCumulativePrecipitation()}
@@ -24,7 +26,10 @@ computeCumulativePrecipRecords <-
              orfwx::computeCumulativePrecipitation(),
            ccprMonth = format(orfwx::yesterdate(), "%m"),
            showYear = FALSE,
-           includeNormals = FALSE) {
+           includeNormals = FALSE,
+           showLeapDay = 
+             orfwx::is.leapYear(as.integer(format(orfwx::yesterdate(), 
+                                                  "%Y")))) {
     # Ensure ccprMonth is an integer between 1 and 12, inclusive.
     ccprMonth <- as.integer(ccprMonth)
     if(ccprMonth < 1 | ccprMonth > 12) {
@@ -194,6 +199,14 @@ computeCumulativePrecipRecords <-
                                       YTDNormal,
                                       minYTDPrecip,
                                       minYTDYear)
+      }
+    }
+    
+    # If this is February, and showLeapDay is FALSE,
+    # hide data for February 29th.
+    if(ccprMonth == 2) {
+      if(!showLeapDay) {
+        recordsFrame <- dplyr::filter(recordsFrame, DayOfMonth != 29)
       }
     }
     

--- a/orfwx/R/plotmtdprecipitation.R
+++ b/orfwx/R/plotmtdprecipitation.R
@@ -13,6 +13,8 @@
 #'   when it defaults to the previous month).
 #' @param saveToFile (optional) Writes plot to a PNG file (defaults to 
 #'   \code{FALSE}).
+#' @param showLeapDay (optional) Whether or not to show data for February 29th
+#'   (defaults to \code{FALSE}, unless the current year is a leap year).
 #' @return Returns a plot.
 #' @examples
 #' \dontrun{
@@ -20,7 +22,10 @@
 #' @export
 plotMTDPrecipitation <- function(plotMonth = format(orfwx::yesterdate(), 
                                                     "%m"),
-                                 saveToFile = FALSE) {
+                                 saveToFile = FALSE,
+                                 showLeapDay = 
+                                   orfwx::is.leapYear(as.integer(format(
+                                     orfwx::yesterdate(), "%Y")))) {
   # DRAFT - not yet suitable for inclusion in package
   plotMonth <- as.integer(plotMonth)
   currentMonth <- as.integer(format(orfwx::yesterdate(), "%m"))
@@ -38,7 +43,8 @@ plotMTDPrecipitation <- function(plotMonth = format(orfwx::yesterdate(),
   gmtd <- ggplot2::ggplot(orfwx::computeCumulativePrecipRecords(
                             ccprMonth = plotMonth,
                             showYear = TRUE,
-                            includeNormals = TRUE),
+                            includeNormals = TRUE,
+                            showLeapDay = showLeapDay),
                           ggplot2::aes(DayOfMonth, 
                                        maxMTDPrecip, 
                                        color = "Maximum")) +

--- a/orfwx/R/plotytdprecipitation.R
+++ b/orfwx/R/plotytdprecipitation.R
@@ -13,6 +13,8 @@
 #'   when it defaults to the previous month).
 #' @param saveToFile (optional) Writes plot to a PNG file (defaults to 
 #'   \code{FALSE}).
+#' @param showLeapDay (optional) Whether or not to show data for February 29th
+#'   (defaults to \code{FALSE}, unless the current year is a leap year).
 #' @return Returns a plot.
 #' @examples
 #' \dontrun{
@@ -20,7 +22,10 @@
 #' @export
 plotYTDPrecipitation <- function(plotMonth = format(orfwx::yesterdate(), 
                                                     "%m"),
-                                 saveToFile = FALSE) {
+                                 saveToFile = FALSE,
+                                 showLeapDay = 
+                                   orfwx::is.leapYear(as.integer(format(
+                                     orfwx::yesterdate(), "%Y")))) {
   # DRAFT - not yet suitable for inclusion in package
   plotMonth <- as.integer(plotMonth)
   currentMonth <- as.integer(format(orfwx::yesterdate(), "%m"))
@@ -38,7 +43,8 @@ plotYTDPrecipitation <- function(plotMonth = format(orfwx::yesterdate(),
   gmtd <- ggplot2::ggplot(orfwx::computeCumulativePrecipRecords(
                             ccprMonth = plotMonth,
                             showYear = TRUE,
-                            includeNormals = TRUE),
+                            includeNormals = TRUE,
+                            showLeapDay = showLeapDay),
                           ggplot2::aes(DayOfMonth, 
                                        maxYTDPrecip, 
                                        color = "Maximum")) +

--- a/orfwx/man/computeCumulativePrecipRecords.Rd
+++ b/orfwx/man/computeCumulativePrecipRecords.Rd
@@ -7,7 +7,9 @@
 
   computeCumulativePrecipRecords(originalFrame = orfwx::computeCumulativePrecipitation(),
   ccprMonth = format(orfwx::yesterdate(), "\%m"), showYear = FALSE,
-  includeNormals = FALSE)
+  includeNormals = FALSE,
+  showLeapDay = orfwx::is.leapYear(as.integer(format(orfwx::yesterdate(),
+  "\%Y"))))
 }
 \arguments{
 \item{originalFrame}{(optional) The data frame to which the \code{MTDPrecip} 
@@ -22,6 +24,9 @@ year's data for comparison (defaults to \code{FALSE}).}
 
 \item{includeNormals}{(optional) Whether or not to show the 1981-2010 
 normals for comparison (defaults to \code{FALSE}).}
+
+\item{showLeapDay}{(optional) Whether or not to show data for February 29th
+(defaults to \code{FALSE}, unless the current year is a leap year).}
 }
 \value{
 Returns a data frame.

--- a/orfwx/man/plotMTDPrecipitation.Rd
+++ b/orfwx/man/plotMTDPrecipitation.Rd
@@ -5,7 +5,9 @@
 \title{Plot month-to-date precipitation}
 \usage{
 plotMTDPrecipitation(plotMonth = format(orfwx::yesterdate(), "\%m"),
-  saveToFile = FALSE)
+  saveToFile = FALSE,
+  showLeapDay = orfwx::is.leapYear(as.integer(format(orfwx::yesterdate(),
+  "\%Y"))))
 }
 \arguments{
 \item{plotMonth}{(optional) The month for which precipitation records are
@@ -14,6 +16,9 @@ when it defaults to the previous month).}
 
 \item{saveToFile}{(optional) Writes plot to a PNG file (defaults to 
 \code{FALSE}).}
+
+\item{showLeapDay}{(optional) Whether or not to show data for February 29th
+(defaults to \code{FALSE}, unless the current year is a leap year).}
 }
 \value{
 Returns a plot.

--- a/orfwx/man/plotYTDPrecipitation.Rd
+++ b/orfwx/man/plotYTDPrecipitation.Rd
@@ -5,7 +5,9 @@
 \title{Plot year-to-date precipitation}
 \usage{
 plotYTDPrecipitation(plotMonth = format(orfwx::yesterdate(), "\%m"),
-  saveToFile = FALSE)
+  saveToFile = FALSE,
+  showLeapDay = orfwx::is.leapYear(as.integer(format(orfwx::yesterdate(),
+  "\%Y"))))
 }
 \arguments{
 \item{plotMonth}{(optional) The month for which precipitation records are
@@ -14,6 +16,9 @@ when it defaults to the previous month).}
 
 \item{saveToFile}{(optional) Writes plot to a PNG file (defaults to 
 \code{FALSE}).}
+
+\item{showLeapDay}{(optional) Whether or not to show data for February 29th
+(defaults to \code{FALSE}, unless the current year is a leap year).}
 }
 \value{
 Returns a plot.


### PR DESCRIPTION
Fixes #61.

Use `showLeapDays` parameter to show Feb 29th; otherwise, it will be hidden (unless in a leap year.)